### PR TITLE
Make the pxe::images reosurce safer for RHEL

### DIFF
--- a/manifests/images.pp
+++ b/manifests/images.pp
@@ -66,15 +66,14 @@ define pxe::images (
       }
     }
     redhat: {
-      pxe::images::redhat {
-        "$os $ver $arch":
-          arch    => "$arch",
-          ver     => "$ver",
-          os      => "$os",
-          baseurl => $baseurl ? {
-            ''      => undef,
-            default => $baseurl
-          };
+      if $baseurl != '' {
+        pxe::images::redhat {
+          "$os $ver $arch":
+            arch    => "$arch",
+            ver     => "$ver",
+            os      => "$os",
+            baseurl => $baseurl,
+        }
       }
     }
     mfsbsd: {


### PR DESCRIPTION
Without this commit, using the `::pxe::images` defined type for RedHat
distros would cause a failure unless a "baseurl" was provided from which
to download the elements needed for PXE beeting. Generally, RedHat
repositories are not publicly availabe and we cannot just grab these
files from a mirror like the other FOSS distrobutions. However, ti would
still be nice to have the directory structure setup so that it could be
manually populated from the ISO.

This commit allows the `::pxe::images` defined tyoe to be used without
providing a "baseurl" parameter.
