### PR TITLE
Updated all templates to use "@variable_name" to get rid of "deprecated" warnings

### DIFF
--- a/manifests/host.pp
+++ b/manifests/host.pp
@@ -30,7 +30,7 @@ define pxe::host (
 
   pxe::menu::host { "$hwaddr":
     kernel => $kernel,
-    append => inline_template("<% appendargs.each do |arg| %><%= arg %> <% end %>"),
+    append => inline_template("<% appendargs.each do |arg| %><%= @arg %> <% end %>"),
   }
 
 }

--- a/manifests/images.pp
+++ b/manifests/images.pp
@@ -24,7 +24,7 @@ define pxe::images (
 ) {
 
   $tftp_root = $::pxe::tftp_root
-  $os_cap    = inline_template("<%= os.capitalize %>")
+  $os_cap    = inline_template("<%= @os.capitalize %>")
 
   # Export the resources needed by all classes
   pxe::images::resources { "$os $ver $arch":

--- a/manifests/images/resources.pp
+++ b/manifests/images/resources.pp
@@ -21,7 +21,7 @@ define pxe::images::resources (
 ) {
 
   $tftp_root = $::pxe::tftp_root
-  $os_cap    = inline_template("<%= os.capitalize %>")
+  $os_cap    = inline_template("<%= @os.capitalize %>")
 
   # directory structure
   if ! defined(File["$tftp_root/images"]) { @file { "$tftp_root/images": ensure => directory; } }

--- a/templates/centos_ks.cfg.erb
+++ b/templates/centos_ks.cfg.erb
@@ -1,5 +1,5 @@
 install 
-url --url http://urd.puppetlabs.lan/yum/centos/<%=ver%>/os/<%=arch%>
+url --url http://urd.puppetlabs.lan/yum/centos/<%=@ver%>/os/<%=@arch%>
 cdrom
 lang en_US.UTF-8
 keyboard us

--- a/templates/menu.erb
+++ b/templates/menu.erb
@@ -1,6 +1,6 @@
-MENU TITLE <%= title %>
+MENU TITLE <%= @title %>
 
-LABEL <%= back %>
+LABEL <%= @back %>
   KERNEL menu.c32
-  APPEND <%= append %>
+  APPEND <%= @append %>
 

--- a/templates/menuentry-header.erb
+++ b/templates/menuentry-header.erb
@@ -2,9 +2,9 @@ default menu.c32
 prompt 0
 timeout 0
 
-MENU TITLE <%= target %> Menu
+MENU TITLE <%= @target %> Menu
 
-LABEL <%= back_name %>
+LABEL <%= @back_name %>
   KERNEL menu.c32
-  APPEND <%= back %>
+  APPEND <%= @back %>
 

--- a/templates/menuentry.erb
+++ b/templates/menuentry.erb
@@ -1,6 +1,6 @@
-LABEL <%= label_string %>
-  KERNEL <%= kernel %>
-<% if append != '' -%>
-  APPEND <%= append %>
+LABEL <%= @label_string %>
+  KERNEL <%= @kernel %>
+<% if @append != '' -%>
+  APPEND <%= @append %>
 <% end -%>
 

--- a/templates/menuhost.erb
+++ b/templates/menuhost.erb
@@ -1,7 +1,7 @@
-DEFAULT <%= label %>
+DEFAULT <%= @label %>
 PROMPT  0
 
-LABEL <%= label %>
-  KERNEL <%= kernel %>
-  APPEND <%= append %>
+LABEL <%= @label %>
+  KERNEL <%= @kernel %>
+  APPEND <%= @append %>
 

--- a/templates/menuinstallentry.erb
+++ b/templates/menuinstallentry.erb
@@ -1,4 +1,4 @@
-LABEL <%= label_string %>
-  KERNEL <%= kernel_string %>
-  APPEND <%= append_string %>
+LABEL <%= @label_string %>
+  KERNEL <%= @kernel_string %>
+  APPEND <%= @append_string %>
 

--- a/templates/preseed.cfg.erb
+++ b/templates/preseed.cfg.erb
@@ -61,9 +61,9 @@ d-i netcfg/wireless_wep string
 # If you select ftp, the mirror/country string does not need to be set.
 #d-i mirror/protocol string ftp
 d-i mirror/country string manual
-d-i mirror/http/hostname string <%= mirror %>
-d-i mirror/http/directory string <%= mirror_directory %>
-<% if has_variable?("proxy") %>d-i mirror/http/proxy string <%= proxy %><%end%>
+d-i mirror/http/hostname string <%= @mirror %>
+d-i mirror/http/directory string <%= @mirror_directory %>
+<% if has_variable?("proxy") %>d-i mirror/http/proxy string <%= @proxy %><%end%>
 
 # Alternatively: by default, the installer uses CC.archive.ubuntu.com where
 # CC is the ISO-3166-2 code for the selected country. You can preseed this
@@ -71,9 +71,9 @@ d-i mirror/http/directory string <%= mirror_directory %>
 #d-i mirror/http/mirror select CC.archive.ubuntu.com
 
 # Suite to install.
-d-i mirror/suite string <%= ver %>
+d-i mirror/suite string <%= @ver %>
 # Suite to use for loading installer components (optional).
-d-i mirror/udeb/suite string <%= ver %>
+d-i mirror/udeb/suite string <%= @ver %>
 # Components to use for loading installer components (optional).
 d-i mirror/udeb/components multiselect main, restricted
 

--- a/templates/tftp_xinetd.erb
+++ b/templates/tftp_xinetd.erb
@@ -10,7 +10,7 @@ service tftp
 	wait			= yes
 	user			= root
 	server			= /usr/sbin/in.tftpd
-  server_args		= -s <%= tftp_root %>
+  server_args		= -s <%= @tftp_root %>
 	disable			= no
 	per_source		= 11
 	cps			= 100 2


### PR DESCRIPTION
Updated all templates to use '@variable_name' to get rid of these warnings:

Warning: Variable access via 'title' is deprecated. Use '@title' instead.
template[/etc/puppetlabs/puppet/modules/pxe/templates/menu.erb]:1
   (at /etc/puppetlabs/puppet/modules/pxe/templates/menu.erb:1:in `block in result')
