### PR TITLE
Make it so it is possible to override baseurl

### DIFF
--- a/manifests/images/debian.pp
+++ b/manifests/images/debian.pp
@@ -15,6 +15,8 @@ define pxe::images::debian(
       'ubuntu': { $srclocation = "http://archive.ubuntu.com/${os}/dists" }
       default:  { $srclocation = "http://mirrors.kernel.org/${os}/dists" }
     }
+  } else {
+    $srclocation = "${baseurl}/${os}/dists"
   }
 
   # http://mirrors.kernel.org/debian/dists/lucid/main/installer-amd64/current/images/netboot/debian-installer/amd64/


### PR DESCRIPTION
baseurl is a parameter that can be set but if it is overridden, it
doesn't work since srclocation is not set.
