### PR TITLE
Ensuring concat file exists for menu entries

### DIFF
--- a/manifests/menu/entry.pp
+++ b/manifests/menu/entry.pp
@@ -36,4 +36,7 @@ define pxe::menu::entry (
     target  => "${fullpath}/${file_string}",
     content => template($template),
   }
+  if !defined(Concat["${fullpath}/${file_string}"]) {
+    concat { "${fullpath}/${file_string}": }
+  }
 }


### PR DESCRIPTION
### Pull Request (PR) description

Ensuring menu entries have a file to go into. Currently, [the `pxe::menu::entry` example given in the README](https://github.com/voxpupuli/puppet-pxe#host-configs) results in a warning similar to:

    Warning: /Stage[main]/Profile::Pxe/Pxe::Menu::Entry[hostname]/Concat::Fragment[00-50-56-8e-b2-37-menu-entry-hostname]/Concat_fragment[00-50-56-8e-b2-37-menu-entry-hostname]: Target Concat_file with path or title '/var/lib/tftpboot/pxelinux.cfg/00-50-56-8e-b2-37' or tag '_var_lib_tftpboot_pxelinux.cfg_00-50-56-8e-b2-37 not found in the catalog

and no file is created.

Ensuring the target concat file exists similar to the method used in [manifests/menu.pp](https://github.com/voxpupuli/puppet-pxe/blob/18ec96a83f86380b905d60b97c21e122ec0d8ccb/manifests/menu.pp#L26) resolves the warning and creates the file.

#### This Pull Request (PR) fixes the following issues

N/A
