### PR TITLE
RHEL missing wget and fixing syslinux_major_version

### DIFF
--- a/manifests/images/centos.pp
+++ b/manifests/images/centos.pp
@@ -22,11 +22,13 @@ define pxe::images::centos(
       path    => ['/usr/bin', '/usr/local/bin'],
       cwd     => "${tftp_root}/images/${os}/${ver}/${arch}",
       creates => "${tftp_root}/images/${os}/${ver}/${arch}/vmlinuz",
-      command => "wget ${srclocation}/vmlinuz";
+      command => "wget ${srclocation}/vmlinuz",
+      require => Class['pxe'];
     "wget ${os} pxe initrd.img ${arch} ${ver}":
       path    => ['/usr/bin', '/usr/local/bin'],
       cwd     => "${tftp_root}/images/${os}/${ver}/${arch}",
       creates => "${tftp_root}/images/${os}/${ver}/${arch}/initrd.img",
-      command => "wget ${srclocation}/initrd.img";
+      command => "wget ${srclocation}/initrd.img",
+      require => Class['pxe'];
   }
 }

--- a/manifests/images/coreos.pp
+++ b/manifests/images/coreos.pp
@@ -25,11 +25,13 @@ define pxe::images::coreos(
       path    => ['/usr/bin', '/usr/local/bin'],
       cwd     => "${tftp_root}/images/${os}/${ver}/${arch}",
       command => "wget ${srclocation}/coreos_production_pxe.vmlinuz",
-      creates => "${tftp_root}/images/${os}/${ver}/${arch}/coreos_production_pxe.vmlinuz";
+      creates => "${tftp_root}/images/${os}/${ver}/${arch}/coreos_production_pxe.vmlinuz",
+      require => Class['pxe'];
     "wget ${os} pxe initrd.img ${arch} ${ver}":
       path    => ['/usr/bin', '/usr/local/bin'],
       cwd     => "${tftp_root}/images/${os}/${ver}/${arch}",
       command => "wget ${srclocation}/coreos_production_pxe_image.cpio.gz",
-      creates => "${tftp_root}/images/${os}/${ver}/${arch}/coreos_production_pxe_image.cpio.gz";
+      creates => "${tftp_root}/images/${os}/${ver}/${arch}/coreos_production_pxe_image.cpio.gz",
+      require => Class['pxe'];
   }
 }

--- a/manifests/images/debian.pp
+++ b/manifests/images/debian.pp
@@ -29,11 +29,13 @@ define pxe::images::debian(
       path    => ['/usr/bin', '/usr/local/bin'],
       cwd     => "${tftp_root}/images/${os}/${ver}/${arch}",
       command => "wget ${srclocation}/${path}/linux",
-      creates => "${tftp_root}/images/${os}/${ver}/${arch}/linux";
+      creates => "${tftp_root}/images/${os}/${ver}/${arch}/linux",
+      require => Class['pxe'];
     "wget ${os} pxe initrd.img ${arch} ${ver}":
       path    => ['/usr/bin', '/usr/local/bin'],
       cwd     => "${tftp_root}/images/${os}/${ver}/${arch}",
       command => "wget ${srclocation}/${path}/initrd.gz",
-      creates => "${tftp_root}/images/${os}/${ver}/${arch}/initrd.gz";
+      creates => "${tftp_root}/images/${os}/${ver}/${arch}/initrd.gz",
+      require => Class['pxe'];
   }
 }

--- a/manifests/images/mfsbsd.pp
+++ b/manifests/images/mfsbsd.pp
@@ -59,5 +59,6 @@ define pxe::images::mfsbsd(
     command => "wget ${remotebase}/${remotedir}/${imgfile}",
     creates => "${localdir}/${imgfile}",
     path    => ['/usr/bin', '/usr/local/bin'],
+    require => Class['pxe'],
   }
 }

--- a/manifests/images/redhat.pp
+++ b/manifests/images/redhat.pp
@@ -20,11 +20,13 @@ define pxe::images::redhat(
       path    => ['/usr/bin', '/usr/local/bin'],
       cwd     => "${tftp_root}/images/redhat/${ver}/${arch}",
       creates => "${tftp_root}/images/redhat/${ver}/${arch}/vmlinuz",
-      command => "wget ${srclocation}/vmlinuz";
+      command => "wget ${srclocation}/vmlinuz",
+      require => Class['pxe'];
     "wget redhat pxe initrd.img ${arch} ${ver}":
       path    => ['/usr/bin', '/usr/local/bin'],
       cwd     => "${tftp_root}/images/redhat/${ver}/${arch}",
       creates => "${tftp_root}/images/redhat/${ver}/${arch}/initrd.img",
-      command => "wget ${srclocation}/initrd.img";
+      command => "wget ${srclocation}/initrd.img",
+      require => Class['pxe'];
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,11 @@ class pxe (
   $tools            = true,
 ) inherits pxe::params {
 
+  # Ensure wget is installed before any execs of wget
+  Package <| |> -> Exec <| |>
+  package { 'wget':
+    ensure => present,
+  }
   class { 'pxe::syslinux':
     tftp_root        => $tftp_root,
     syslinux_version => $syslinux_version,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,11 +9,8 @@ class pxe (
   $tools            = true,
 ) inherits pxe::params {
 
-  # Ensure wget is installed before any execs of wget
-  Package <| |> -> Exec <| |>
-  package { 'wget':
-    ensure => present,
-  }
+  ensure_packages(['wget'], 'ensure' => 'present')
+
   class { 'pxe::syslinux':
     tftp_root        => $tftp_root,
     syslinux_version => $syslinux_version,

--- a/manifests/syslinux.pp
+++ b/manifests/syslinux.pp
@@ -12,7 +12,7 @@ class pxe::syslinux(
       syslinux_dir => $system_syslinux_dir,
       tftp_root    => $tftp_root,
     }
-  } elsif $syslinux_version =~ /^[1-9]/ {
+  } elsif $syslinux_version =~ /^([1-9]+)\./ {
     $syslinux_major_version = $1
     class { 'pxe::syslinux::direct':
       syslinux_dir     => "/usr/local/src/syslinux-${syslinux_version}",

--- a/manifests/syslinux/direct.pp
+++ b/manifests/syslinux/direct.pp
@@ -9,6 +9,7 @@ class pxe::syslinux::direct(
     cwd     => '/usr/local/src',
     command => "wget -q -O - ${syslinux_archive} | tar -xzf - -C `dirname ${syslinux_dir}`",
     creates => $syslinux_dir,
+    require => Class['pxe'],
   }
 
   file { "${tftp_root}/pxelinux.0":

--- a/manifests/tools.pp
+++ b/manifests/tools.pp
@@ -4,6 +4,8 @@
 #
 class pxe::tools {
 
+  require Class['pxe']
+
   $tftp_root = $pxe::tftp_root
 
   # Create the directory to store all the tool images


### PR DESCRIPTION
#### Pull Request (PR) description

First, RHEL's recommended `minimal` package group does not include `wget`. Ensuring it's installed before any of the `exec` resources are applied. If the `package` resource is enough on its own, could remove the dependency.

Second, it appears the code to find `syslinux_major_version` is missing a group for its back-reference. Also adjusted the regex to allow for major versions higher than 9.

#### This Pull Request (PR) fixes the following issues

N/A