### PR TITLE
Correcting regex for syslinux_major_version

### DIFF
--- a/manifests/syslinux.pp
+++ b/manifests/syslinux.pp
@@ -12,7 +12,7 @@ class pxe::syslinux(
       syslinux_dir => $system_syslinux_dir,
       tftp_root    => $tftp_root,
     }
-  } elsif $syslinux_version =~ /^([1-9]+)\./ {
+  } elsif $syslinux_version =~ /^([0-9]+)\./ {
     $syslinux_major_version = $1
     class { 'pxe::syslinux::direct':
       syslinux_dir     => "/usr/local/src/syslinux-${syslinux_version}",

--- a/manifests/syslinux.pp
+++ b/manifests/syslinux.pp
@@ -12,7 +12,7 @@ class pxe::syslinux(
       syslinux_dir => $system_syslinux_dir,
       tftp_root    => $tftp_root,
     }
-  } elsif $syslinux_version =~ /^[1-9]/ {
+  } elsif $syslinux_version =~ /^([1-9]+)\./ {
     $syslinux_major_version = $1
     class { 'pxe::syslinux::direct':
       syslinux_dir     => "/usr/local/src/syslinux-${syslinux_version}",


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

Previously, there was no capture group for the major version, resulting in `syslinux_major_version` getting set to an empty string. This will also work if syslinux ever reaches a major version higher than 9.

#### This Pull Request (PR) fixes the following issues

N/A