### PR TITLE
Patch 1

### DIFF
--- a/manifests/syslinux/system.pp
+++ b/manifests/syslinux/system.pp
@@ -9,6 +9,11 @@ class pxe::syslinux::system (
     require => Package['syslinux'],
   }
 
+  file { "${tftp_root}/syslinux/ldlinux.c32":
+    source  => "${syslinux_dir}/ldlinux.c32",
+    require => Package['syslinux'],
+  }
+
   file { "${tftp_root}/syslinux/menu.c32":
     source  => "${syslinux_dir}/menu.c32",
     require => Package['syslinux'],
@@ -16,6 +21,11 @@ class pxe::syslinux::system (
 
   file { "${tftp_root}/syslinux/vesamenu.c32":
     source  => "${syslinux_dir}/vesamenu.c32",
+    require => Package['syslinux'],
+  }
+
+  file { "${tftp_root}/syslinux/libutil.c32":
+    source  => "${syslinux_dir}/libutil.c32",
     require => Package['syslinux'],
   }
 

--- a/spec/classes/syslinux/system_spec.rb
+++ b/spec/classes/syslinux/system_spec.rb
@@ -14,6 +14,8 @@ describe 'pxe::syslinux::system' do
     it { is_expected.to contain_File('/srv/tftp/syslinux/memdisk') }
     it { is_expected.to contain_File('/srv/tftp/syslinux/menu.c32') }
     it { is_expected.to contain_file('/srv/tftp/syslinux/reboot.c32') }
+    it { is_expected.to contain_file('/srv/tftp/syslinux/ldlinux.c32') }
+    it { is_expected.to contain_file('/srv/tftp/syslinux/libutil.c32') }
     it { is_expected.to contain_file('/srv/tftp/syslinux/vesamenu.c32') }
   end
 end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Adds ldlinux.c32 and libutil.c32 to the files copied from syslinux to tftp area

#### This Pull Request (PR) fixes the following issues
Issue: N/A

These are required for booting. At least with the syslinux that comes on RHEL8 PXE booting a vmWare guest.

Example of successful PXE boot's logs:
```
Oct 28 17:36:09 vmc-lnx-mgmt-1 in.tftpd[4164872]: Client 10.161.16.61 finished pxelinux.0
Oct 28 17:36:09 vmc-lnx-mgmt-1 in.tftpd[4164879]: Client 10.161.16.61 finished /syslinux/ldlinux.c32
Oct 28 17:36:09 vmc-lnx-mgmt-1 in.tftpd[4164890]: Client 10.161.16.61 finished pxelinux.cfg/default
Oct 28 17:36:09 vmc-lnx-mgmt-1 in.tftpd[4164892]: Client 10.161.16.61 finished /syslinux/menu.c32
Oct 28 17:36:09 vmc-lnx-mgmt-1 in.tftpd[4164894]: Client 10.161.16.61 finished /syslinux/libutil.c32
Oct 28 17:36:09 vmc-lnx-mgmt-1 in.tftpd[4164895]: Client 10.161.16.61 finished pxelinux.cfg/default
Oct 28 17:36:10 vmc-lnx-mgmt-1 in.tftpd[4164897]: Client 10.161.16.61 finished /syslinux/menu.c32
Oct 28 17:36:10 vmc-lnx-mgmt-1 in.tftpd[4164899]: Client 10.161.16.61 finished /syslinux/libutil.c32
Oct 28 17:36:10 vmc-lnx-mgmt-1 in.tftpd[4164900]: Client 10.161.16.61 finished pxelinux.cfg/menu_install
Oct 28 17:36:11 vmc-lnx-mgmt-1 in.tftpd[4164902]: Client 10.161.16.61 finished /syslinux/menu.c32
Oct 28 17:36:11 vmc-lnx-mgmt-1 in.tftpd[4164904]: Client 10.161.16.61 finished /syslinux/libutil.c32
Oct 28 17:36:11 vmc-lnx-mgmt-1 in.tftpd[4164905]: Client 10.161.16.61 finished pxelinux.cfg/os_centos
Oct 28 17:36:13 vmc-lnx-mgmt-1 in.tftpd[4164906]: Client 10.161.16.61 finished images/centos/8/x86_64/vmlinuz
Oct 28 17:36:20 vmc-lnx-mgmt-1 in.tftpd[4164907]: Client 10.161.16.61 finished images/centos/8/x86_64/initrd.img
```
