### PR TITLE
Allow multiple menu entires per OS/version/architecture combination

### DIFF
--- a/manifests/installer.pp
+++ b/manifests/installer.pp
@@ -19,12 +19,14 @@ define pxe::installer (
     Pxe::Menu::Entry <||>
   }
 
-  pxe::images { $title:
-    os      => $os,
-    ver     => $ver,
-    arch    => $arch,
-    netboot => $netboot,
-    baseurl => $baseurl,
+  unless defined(Pxe::Images["${os} ${ver} ${arch}"]) {
+    pxe::images { "${os} ${ver} ${arch}":
+      os      => $os,
+      ver     => $ver,
+      arch    => $arch,
+      netboot => $netboot,
+      baseurl => $baseurl,
+    }
   }
 
   $append_string = inline_template($append)

--- a/manifests/installer.pp
+++ b/manifests/installer.pp
@@ -19,7 +19,7 @@ define pxe::installer (
     Pxe::Menu::Entry <||>
   }
 
-  pxe::images { "${os} ${ver} ${arch}":
+  pxe::images { $title:
     os      => $os,
     ver     => $ver,
     arch    => $arch,
@@ -30,7 +30,7 @@ define pxe::installer (
   $append_string = inline_template($append)
   $kernel_string = inline_template($kernel)
 
-  pxe::menu::entry { "Installer: ${os} ${ver} ${arch}":
+  pxe::menu::entry { "Installer: ${title}":
     file   => "os_${os}",
     kernel => $kernel_string,
     append => $append_string,


### PR DESCRIPTION
#### Pull Request (PR) description

Allow multiple menu entries per OS/version/architecture (e.g., both interactive installs and Kickstart/Preseed/Cloud-Init)

#### This Pull Request (PR) fixes the following issues

None.